### PR TITLE
Adds preconcurrency attribute support for imports

### DIFF
--- a/Arbitrary.stencil
+++ b/Arbitrary.stencil
@@ -1,6 +1,6 @@
 {%  for type in types.all where type.name == "SourceryImports_Arbitrary" %}
 {% for variable in type.variables %}
-{% if variable|annotated:"testable" %}@testable {% else %}{% endif %}import {{ variable.name }}
+{% if variable|annotated:"testable" %}@testable {% else %}{% endif %}{% if variable|annotated:"preconcurrency" %}@preconcurrency {% else %}{% endif %}import {{ variable.name }}
 {% endfor %}
 
 {% endfor %}

--- a/Equatable.stencil
+++ b/Equatable.stencil
@@ -1,6 +1,6 @@
 {%  for type in types.all where type.name == "SourceryImports_Equatable" %}
 {% for variable in type.variables %}
-{% if variable|annotated:"testable" %}@testable {% else %}{% endif %}import {{ variable.name }}
+{% if variable|annotated:"testable" %}@testable {% else %}{% endif %}{% if variable|annotated:"preconcurrency" %}@preconcurrency {% else %}{% endif %}import {{ variable.name }}
 {% endfor %}
 
 {% endfor %}

--- a/Lens.stencil
+++ b/Lens.stencil
@@ -1,6 +1,6 @@
 {%  for type in types.all where type.name == "SourceryImports_Lens" %}
 {% for variable in type.variables %}
-{% if variable|annotated:"testable" %}@testable {% else %}{% endif %}import {{ variable.name }}
+{% if variable|annotated:"testable" %}@testable {% else %}{% endif %}{% if variable|annotated:"preconcurrency" %}@preconcurrency {% else %}{% endif %}import {{ variable.name }}
 {% endfor %}
 
 {% endfor %}

--- a/Match.stencil
+++ b/Match.stencil
@@ -2,7 +2,7 @@
 
 {%  for type in types.all where type.name == "SourceryImports_Match" %}
 {% for variable in type.variables %}
-{% if variable|annotated:"testable" %}@testable {% else %}{% endif %}import {{ variable.name }}
+{% if variable|annotated:"testable" %}@testable {% else %}{% endif %}{% if variable|annotated:"preconcurrency" %}@preconcurrency {% else %}{% endif %}import {{ variable.name }}
 {% endfor %}
 
 {% endfor %}

--- a/Prism.stencil
+++ b/Prism.stencil
@@ -2,7 +2,7 @@
 
 {%  for type in types.all where type.name == "SourceryImports_Prism" %}
 {% for variable in type.variables %}
-{% if variable|annotated:"testable" %}@testable {% else %}{% endif %}import {{ variable.name }}
+{% if variable|annotated:"testable" %}@testable {% else %}{% endif %}{% if variable|annotated:"preconcurrency" %}@preconcurrency {% else %}{% endif %}import {{ variable.name }}
 {% endfor %}
 
 {% endfor %}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ import Foo
 import Bar
 ```
 
-To each property you can add a `// sourcery: testable` annotation to add a `@testable` attribute to the `import`.
+To each property you can add a `// sourcery: testable` annotation to add a `@testable` attribute to the `import`. 
+
+Furthermore, you can also add a `// sourcery: preconcurrency` annotation to add a `@preconcurrency` attribute to the `import`.
 
 ------
 


### PR DESCRIPTION
This Pull request:

- adds preconcurrency support attribute using `// sourcery: preconcurrency` annotation to SourceryImports. 